### PR TITLE
fix: suppress `formats` deprecation warning in Upload.Controller

### DIFF
--- a/lib/upload/upload_controller.ex
+++ b/lib/upload/upload_controller.ex
@@ -22,7 +22,7 @@ defmodule CKEditor5.Upload.Controller do
 
   """
 
-  use Phoenix.Controller
+  use Phoenix.Controller, formats: []
 
   @doc """
   Handles file upload from CKEditor 5.


### PR DESCRIPTION
## Summary

- Fixes the Phoenix 1.7+ deprecation warning: `use CKEditor5.Upload.Controller must receive the :formats option`
- Changes `use Phoenix.Controller` to `use Phoenix.Controller, formats: []` in `lib/upload/upload_controller.ex`
- `formats: []` is correct because the controller uses `json/2` directly and never calls `render/3` with view modules

## Backward Compatibility

**No breaking changes.** The `:formats` option was introduced in Phoenix 1.7.0, which is already the minimum version required by this package (`{:phoenix, "~> 1.7"}`). This fix is compatible with all supported Phoenix versions.

## Test Environment

- Elixir 1.18.3 (compiled with Erlang/OTP 27)
- Erlang/OTP 28 [erts-16.0]

## Test Plan

- [ ] Verify the deprecation warning no longer appears when compiling a project that depends on `ckeditor5_phoenix`
- [ ] Verify file uploads still return JSON responses correctly via `json/2`